### PR TITLE
US224 Task244: Image Folder filepicker

### DIFF
--- a/BSSCSFramework/NN-GUI/App.py
+++ b/BSSCSFramework/NN-GUI/App.py
@@ -1,4 +1,5 @@
-#using the tutorials here: https://build-system.fman.io/pyqt5-tutorial INFO ON TURNING INTO STANDALONE .EXE AT THE END
+#using the tutorials here:
+#(BASIC TUTORIAL) https://build-system.fman.io/pyqt5-tutorial INFO ON TURNING INTO STANDALONE .EXE AT THE END
 #(FILE DIALOGS / BASIC GUI SETUP) http://zetcode.com/gui/pyqt5/dialogs/
 #CURRENTLY NOT USED (FILE DIALOGS) https://pythonspot.com/pyqt5-file-dialog/
 #CURRENTLY NOT USED (STYLES) http://doc.qt.io/qt-5/qtwidgets-index.html#styles
@@ -18,12 +19,22 @@ class NNGUI(QWidget):
         csv_filepath.setReadOnly(True)
         csv_button = QPushButton("Choose a .CSV File")
         def csv_clicked():
-            csv_filepicker = QFileDialog.getOpenFileName(self, "CSV File Picker", "/home", "CSV (*.csv)")
+            csv_filepicker = QFileDialog.getOpenFileName(self, "CSV File Picker", "", "CSV (*.csv)")
             csv_filepath.setText(csv_filepicker[0])
-
         csv_button.clicked.connect(csv_clicked)
+
+        imgfolder_filepath = QLineEdit("Image Folder Filename Here")
+        imgfolder_filepath.setReadOnly(True)
+        imgfolder_button = QPushButton("Choose an Image Folder")
+        def imgfolder_clicked():
+            imgfolder_filepicker = QFileDialog.getExistingDirectory(self, "Image Folder File Picker", "")
+            imgfolder_filepath.setText(imgfolder_filepicker)
+        imgfolder_button.clicked.connect(imgfolder_clicked)
+        
         layout.addWidget(csv_filepath)
         layout.addWidget(csv_button)
+        layout.addWidget(imgfolder_filepath)
+        layout.addWidget(imgfolder_button)
         self.setGeometry(300, 300, 350, 300)
         self.setLayout(layout)
         self.show()


### PR DESCRIPTION
# What does this implement? Explain.

adds the picker for image folder, could probably be improved by being able to double click a folder, which currently needs to be selected by the button at the bottom

# What US and Task is this pull request associated with?

us224 task244

# What are the preconditions and postconditions for this PR?

pre: no filepicker for img folders
post: its there

# Include screenshots (if applicable)
